### PR TITLE
ConnectionManagers shouldn't be closed, otherwise a new API instance is required per connection. Also adding ConfiglessCustomHTTPEngine again to not need to create a new API per request when using Cookie auth.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -152,5 +152,5 @@
 		</plugins>
 		<finalName>redhat-support-lib-java</finalName>
 	</build>
-	<version>2.0.1-SNAPSHOT</version>
+	<version>2.0.2-SNAPSHOT</version>
 </project>

--- a/src/main/java/com/redhat/gss/redhat_support_lib/infrastructure/BaseQuery.java
+++ b/src/main/java/com/redhat/gss/redhat_support_lib/infrastructure/BaseQuery.java
@@ -37,7 +37,6 @@ public class BaseQuery {
 					+ " - " + response.getStatusInfo().getReasonPhrase());
 		}
 		T returnObject = response.readEntity(c);
-		client.close();
 		return returnObject;
 
 	}
@@ -73,7 +72,6 @@ public class BaseQuery {
 		}
 
 		T returnObject = response.readEntity(c);
-		client.close();
 		return returnObject;
 	}
 

--- a/src/main/java/com/redhat/gss/redhat_support_lib/web/ConfiglessCustomHttpEngine.java
+++ b/src/main/java/com/redhat/gss/redhat_support_lib/web/ConfiglessCustomHttpEngine.java
@@ -1,0 +1,62 @@
+package com.redhat.gss.redhat_support_lib.web;
+
+import com.redhat.gss.redhat_support_lib.helpers.ConfigHelper;
+import org.apache.http.HttpHost;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.client.CredentialsProvider;
+import org.apache.http.conn.HttpClientConnectionManager;
+import org.apache.http.impl.client.BasicCredentialsProvider;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.jboss.resteasy.client.jaxrs.engines.ApacheHttpClient4Engine;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+
+
+public class ConfiglessCustomHttpEngine extends ApacheHttpClient4Engine {
+
+
+    public ConfiglessCustomHttpEngine() {
+        super();
+        HttpClientBuilder client = HttpClientBuilder.create();
+
+        try {
+            client.setSslcontext(createGullibleSslContext());
+        } catch (KeyManagementException e) {
+            e.printStackTrace();
+        } catch (NoSuchAlgorithmException e) {
+            e.printStackTrace();
+        }
+        this.httpClient = client.build();
+    }
+
+    public static TrustManager[] gullibleManagers = new TrustManager[]{new X509TrustManager() {
+
+        public void checkClientTrusted(X509Certificate[] arg0, String arg1)
+                throws CertificateException {
+        }
+
+        public void checkServerTrusted(X509Certificate[] arg0, String arg1)
+                throws CertificateException {
+        }
+
+        public X509Certificate[] getAcceptedIssuers() {
+            return null;
+        }
+    }};
+
+    public static SSLContext createGullibleSslContext()
+            throws NoSuchAlgorithmException, KeyManagementException {
+        SSLContext ctx = SSLContext.getInstance("SSL");
+        ctx.init(null, gullibleManagers, new SecureRandom());
+        return ctx;
+    }
+}
+

--- a/src/main/java/com/redhat/gss/redhat_support_lib/web/ConnectionManager.java
+++ b/src/main/java/com/redhat/gss/redhat_support_lib/web/ConnectionManager.java
@@ -20,6 +20,7 @@ public class ConnectionManager {
 	private final static Logger LOGGER = Logger.getLogger(ConnectionManager.class.getName());
 	ResteasyClientBuilder clientBuilder = new ResteasyClientBuilder().connectionPoolSize(100);
 	ConfigHelper config = null;
+    ResteasyClient client = null;
 
 	public ConnectionManager(ConfigHelper config) {
 		this.config = config;
@@ -36,14 +37,21 @@ public class ConnectionManager {
 		}
 	}
 
-	public ResteasyClient getConnection() throws MalformedURLException {
-        ResteasyClient client = clientBuilder.build();
-        if (config.getUsername() != null) {
-            client.register(new BasicAuthentication(config.getUsername(), config
-                    .getPassword()));
+    public ConnectionManager(ConfigHelper config, ResteasyClientBuilder clientBuilder) {
+        this.config = config;
+        this.clientBuilder = clientBuilder;
+    }
+
+    public ResteasyClient getConnection() throws MalformedURLException {
+        if(client == null) {
+            client = clientBuilder.build();
+            if (config.getUsername() != null) {
+                client.register(new BasicAuthentication(config.getUsername(), config
+                        .getPassword()));
+            }
+            client.register(new UserAgentFilter(config.getUserAgent()));
+            client.register(new RedHatCookieFilter(config.getCookies()));
         }
-        client.register(new UserAgentFilter(config.getUserAgent()));
-        client.register(new RedHatCookieFilter(config.getCookies()));
 		return client;
 	}
 


### PR DESCRIPTION
ConnectionManagers shouldn't be closed, otherwise a new API instance is required per connection. Also adding ConfiglessCustomHTTPEngine again to not need to create a new API per request when using Cookie auth.
